### PR TITLE
Moved default route to /templates-list

### DIFF
--- a/src/routes.tsx
+++ b/src/routes.tsx
@@ -1,5 +1,5 @@
 import type { ReactNode } from 'react';
-import { Switch, Route, useRouteMatch } from 'react-router-dom';
+import { Switch, Route, useRouteMatch, Redirect } from 'react-router-dom';
 import Spacings from '@commercetools-uikit/spacings';
 import Emailer from './components/emailer';
 import TemplatesList from './components/templates-list';
@@ -28,9 +28,10 @@ const ApplicationRoutes = (_props: ApplicationRoutesProps) => {
         <Route path={`${match.path}/creator`}>
           <Emailer linkToDashboard={`${basePath}/templates-list`} />
         </Route>
-        <Route path={`${match.path}/`}>
+        <Route path={`${match.path}/templates-list`}>
           <TemplatesList />
         </Route>
+        <Redirect exact from={`${match.path}`} to={`${match.path}/templates-list`} />
       </Switch>
     </Spacings.Inset>
   );


### PR DESCRIPTION
Moved the templates list to /templates-list
Added a redirect from / to /templates-list

This fixed a 404 I was having after deploying the application where the edit button went to https://mc.us-central1.gcp.commercetools.com/aries_dev-1/creator?templateId=e9818454-1703-4a30-b2c9-817506ae20ab causing a 404 error.